### PR TITLE
cpp: Add more comprehensive example  

### DIFF
--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -1,11 +1,21 @@
 .PHONY: build
-build: pie no-pie with-clang
+build: pie pie-with-fp no-pie no-pie-with-fp clang clang-with-fp
 
 pie:
 	docker build -t parca-demo:cpp-pie --build-arg GCC_FLAGS='-g' .
 
+pie-with-fp:
+	docker build -t parca-demo:cpp-pie-with-fp --build-arg GCC_FLAGS='-g -fno-omit-frame-pointer' .
+
+
 no-pie:
 	docker build -t parca-demo:cpp --build-arg GCC_FLAGS='-g -no-pie' .
 
-with-clang:
+no-pie-with-fp:
+	docker build -t parca-demo:cpp-with-fp --build-arg GCC_FLAGS='-g -no-pie -fno-omit-frame-pointer' .
+
+clang:
 	docker build -f Dockerfile.clang -t parca-demo:cpp-clang --build-arg CLANG_FLAGS='-g' .
+
+clang-with-fp:
+	docker build -f Dockerfile.clang -t parca-demo:cpp-clang-with-fp --build-arg CLANG_FLAGS='-g -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer' .

--- a/cpp/main.cpp
+++ b/cpp/main.cpp
@@ -1,27 +1,37 @@
+#include <fcntl.h>
 #include <iostream>
+#include <unistd.h>
 
-unsigned int fibonacci(unsigned int n)
-{
-    if (n == 0)
-        return 0;
 
-    unsigned int a = 1, b = 1;
-    for (unsigned int i = 3; i <= n; ++i)
-    {
-        unsigned int fib = a + b;
-        a = b;
-        b = fib;
-    }
+int __attribute__((noinline)) top() {
+  for (int i = 0; i < 100000; i++) {
+    int fd = open("/", O_DIRECTORY);
+    close(fd);
+  }
 
-    return b;
+  return 0;
 }
 
-int main()
-{
-    int limit = 1000000;
-    for (int i = 0; i < limit; i++)
-    {
-        std::cout << "F(" << i << ") = " << fibonacci(i) << std::endl;
-    }
-    return 0;
+// ones
+int __attribute__((noinline)) c1() { return top(); }
+
+int __attribute__((noinline)) b1() { return c1(); }
+
+int __attribute__((noinline)) a1() { return b1(); }
+
+// twos
+int __attribute__((noinline)) c2() { return top(); }
+
+int __attribute__((noinline)) b2() { return c2(); }
+
+int __attribute__((noinline)) a2() { return b2(); }
+
+int main() {
+  while (true) {
+    std::cout << "Calling a1" << std::endl;
+    a1();
+    std::cout << "Calling a2" << std::endl;
+    a2();
+  }
+  return 0;
 }


### PR DESCRIPTION
This way we can quickly see whether there's any bias in our profiler, as frames with ones and with twos should the same count (same width in the flamegraph) as well as making sure that we handle libc + kernel stacks properly.

This PR also adds versions with frame pointers.

## Test plan
```
$ make build && docker run -it  parca-demo:cpp-clang-with-fp
```

```
$ sudo perf record -g --call-graph=dwarf  --pid=`pidof parca-demo` 
$ sudo perf script | ./FlameGraph/stackcollapse-perf.pl > out.perf-folded
$ ./FlameGraph/flamegraph.pl out.perf-folded > perf.svg
```

<img width="1078" alt="image" src="https://user-images.githubusercontent.com/959128/176488631-ea65a470-ddfe-44eb-9404-07c3935e323e.png">

cc @Sylfrena @kakkoyun 

