### PR TITLE
cpp: Add libc with frame pointers

### DIFF
--- a/cpp/Dockerfile
+++ b/cpp/Dockerfile
@@ -9,9 +9,11 @@ COPY main.cpp .
 
 RUN g++ ${GCC_FLAGS} -o parca-demo main.cpp
 
-FROM debian:stable-slim as runner
-RUN apt-get update && apt-get install libc6-dbg libstdc++6-10-dbg -y
+FROM ubuntu:focal as runner
+RUN apt-get update && apt-get install libc6-prof libstdc++6-10-dbg -y
 
 COPY --from=builder /app/parca-demo .
 
+ARG LD_LIBRARY_PATH
+ENV LD_LIBRARY_PATH ${LD_LIBRARY_PATH}
 CMD ["./parca-demo"]

--- a/cpp/Dockerfile.clang
+++ b/cpp/Dockerfile.clang
@@ -9,9 +9,11 @@ COPY main.cpp .
 
 RUN clang++ ${CLANG_FLAGS} -o parca-demo main.cpp
 
-FROM debian:stable-slim as runner
-RUN apt-get update && apt-get install libc6-dbg libstdc++6-10-dbg -y
+FROM ubuntu:focal as runner
+RUN apt-get update && apt-get install libc6-prof libstdc++6-10-dbg -y
 
 COPY --from=builder /app/parca-demo .
 
+ARG LD_LIBRARY_PATH
+ENV LD_LIBRARY_PATH ${LD_LIBRARY_PATH}
 CMD ["./parca-demo"]

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -5,17 +5,17 @@ pie:
 	docker build -t parca-demo:cpp-pie --build-arg GCC_FLAGS='-g' .
 
 pie-with-fp:
-	docker build -t parca-demo:cpp-pie-with-fp --build-arg GCC_FLAGS='-g -fno-omit-frame-pointer' .
+	docker build -t parca-demo:cpp-pie-with-fp --build-arg GCC_FLAGS='-g -fno-omit-frame-pointer' --build-arg LD_LIBRARY_PATH='/usr/lib/libc6-prof/x86_64-linux-gnu' .
 
 
 no-pie:
 	docker build -t parca-demo:cpp --build-arg GCC_FLAGS='-g -no-pie' .
 
 no-pie-with-fp:
-	docker build -t parca-demo:cpp-with-fp --build-arg GCC_FLAGS='-g -no-pie -fno-omit-frame-pointer' .
+	docker build -t parca-demo:cpp-with-fp --build-arg GCC_FLAGS='-g -no-pie -fno-omit-frame-pointer' --build-arg LD_LIBRARY_PATH='/usr/lib/libc6-prof/x86_64-linux-gnu' .
 
 clang:
 	docker build -f Dockerfile.clang -t parca-demo:cpp-clang --build-arg CLANG_FLAGS='-g' .
 
 clang-with-fp:
-	docker build -f Dockerfile.clang -t parca-demo:cpp-clang-with-fp --build-arg CLANG_FLAGS='-g -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer' .
+	docker build -f Dockerfile.clang -t parca-demo:cpp-clang-with-fp --build-arg CLANG_FLAGS='-g -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer' --build-arg LD_LIBRARY_PATH='/usr/lib/libc6-prof/x86_64-linux-gnu' .


### PR DESCRIPTION
Unfortunately, could not find a counterpart of `libc6-prof` for Debian, so using an Ubuntu image now

## Test plan

**The correct libc is used**

```
(gdb) info sharedlibrary
From                To                  Syms Read   Shared Object Library
0x00007f1cc889b3c0  0x00007f1cc8941528  Yes (*)     target:/usr/lib/libc6-prof/x86_64-linux-gnu/libm.so.6
[...]
```

**Stack walking with frame pointers works**

```
$ sudo perf record -g --call-graph=fp  --pid=`pidof parca-demo`
$ sudo perf script | ./FlameGraph/stackcollapse-perf.pl > out.perf-folded
$ ./FlameGraph/flamegraph.pl out.perf-folded > perf.svg
```

<img width="1078" alt="image" src="https://user-images.githubusercontent.com/959128/176621174-7c147e31-032f-4794-933f-571cba076e7b.png">

**Spot checked some functions to see if the assembly has the frame setup**

```
(gdb) disassemble select
[...]
   0x00007f1cc87994a8 <+40>:	push   %rbp
   0x00007f1cc87994a9 <+41>:	mov    %rsp,%rbp
[...]
   0x00007f1cc87994fb <+123>:	leave 
```
the `leave` instruction pops the frame pointer (https://c9x.me/x86/html/file_module_x86_id_154.html)

```
(gdb) pipe disassemble dup2 | grep rbp
(gdb) pipe disassemble dup | grep rbp
```

don't touch the frame pointer, (they can still be identified with the value of the instruction pointer, right?), this might be a leaf function optimisation.

```
(gdb) disassemble open64
   0x00007f1cc8791e00 <+0>:	endbr64
   0x00007f1cc8791e04 <+4>:	push   %rbp
   0x00007f1cc8791e05 <+5>:	mov    %esi,%r10d
   0x00007f1cc8791e08 <+8>:	mov    %rsp,%rbp
[...]
   0x00007f1cc8791e85 <+133>:	pop    %rbp
   0x00007f1cc8791e86 <+134>:	ret
```
"standard" frame setup and tearing down

```
(gdb) disassemble close
[...]
   0x00007f1cc8792960 <+32>:	push   %rbp
   0x00007f1cc8792961 <+33>:	mov    %rsp,%rbp
[...]
   0x00007f1cc8792993 <+83>:	leave
```
same as select(2) above
## Observations

The function prologue in some of the libc functions looks 'non-standard', either it happens a bit after the actual function starts, or it uses other instructions before returning rather than `pop $rbp`, but I believe that it could be due to:
- [Stack protection](https://stackoverflow.com/questions/1629685/when-and-how-to-use-gccs-stack-protection-feature) mechanisms (that are inserted before the frame setup):
```
(gdb) disassemble close
Dump of assembler code for function close:
   0x00007f1cc8792940 <+0>:	endbr64
   0x00007f1cc8792944 <+4>:	mov    %fs:0x18,%eax
   0x00007f1cc879294c <+12>:	test   %eax,%eax
   0x00007f1cc879294e <+14>:	jne    0x7f1cc8792960 <close+32>
   0x00007f1cc8792950 <+16>:	mov    $0x3,%eax
```

- Leaf function optimisation  / [Red zone](https://w.wiki/5NX5).
Sometimes the frame pointer isn't set-up in leaf functions. One of the reasons is if the stack isn't modified due to using the red zone
- The `__close` frame should be above `top`! My assumption is that we are sampling just before the stack frame for `__close` has been set up, as I have verified under GDB that the frame prologue and epilogue get to run. This requires more investigation, though.