### PR TITLE
feat: add GraalVM example

### DIFF
--- a/graalvm/.gitignore
+++ b/graalvm/.gitignore
@@ -1,0 +1,31 @@
+# Created by https://www.toptal.com/developers/gitignore/api/gradle
+# Edit at https://www.toptal.com/developers/gitignore?templates=gradle
+
+### Gradle ###
+.gradle
+**/build/
+!src/**/build/
+
+# Ignore Gradle GUI config
+gradle-app.setting
+
+# Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
+!gradle-wrapper.jar
+
+# Avoid ignore Gradle wrappper properties
+!gradle-wrapper.properties
+
+# Cache of project
+.gradletasknamecache
+
+# Eclipse Gradle plugin generated files
+# Eclipse Core
+.project
+# JDT-specific (Eclipse Java Development Tools)
+.classpath
+
+### Gradle Patch ###
+# Java heap dump
+*.hprof
+
+# End of https://www.toptal.com/developers/gitignore/api/gradle

--- a/graalvm/Dockerfile
+++ b/graalvm/Dockerfile
@@ -17,9 +17,9 @@ RUN curl -sSfo /tmp/sdkman-intall.sh 'https://get.sdkman.io' \
     && bash /tmp/sdkman-intall.sh
 
 RUN bash -c 'source ~/.sdkman/bin/sdkman-init.sh \
-        && sdk install gradle 7.5.1 \
-        && sdk install java 22.1.0.r11-grl \
-        && sdk use java 22.1.0.r11-grl \
+        && sdk install gradle 7.6 \
+        && sdk install java 22.3.r19-grl \
+        && sdk use java 22.3.r19-grl \
         && gu install native-image'
 
 COPY . .

--- a/graalvm/Dockerfile
+++ b/graalvm/Dockerfile
@@ -1,0 +1,32 @@
+FROM debian:11 AS builder
+
+WORKDIR /app
+
+# hadolint ignore=DL3008
+RUN apt-get update \
+    &&  apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        gcc \
+        libstdc++-10-dev \
+        unzip \
+        zip \
+        zlib1g-dev
+
+RUN curl -sSfo /tmp/sdkman-intall.sh 'https://get.sdkman.io' \
+    && bash /tmp/sdkman-intall.sh
+
+RUN bash -c 'source ~/.sdkman/bin/sdkman-init.sh \
+        && sdk install gradle 7.5.1 \
+        && sdk install java 22.1.0.r11-grl \
+        && sdk use java 22.1.0.r11-grl \
+        && gu install native-image'
+
+COPY . .
+
+RUN bash -c 'source ~/.sdkman/bin/sdkman-init.sh && gradle nativeCompile'
+
+FROM gcr.io/distroless/static:nonroot
+
+COPY --from=builder /app/build/native/nativeCompile/demo /bin/demo
+CMD ["/bin/demo"]

--- a/graalvm/Makefile
+++ b/graalvm/Makefile
@@ -1,0 +1,3 @@
+.PHONY: build
+build:
+	docker build -t parca-demo:graalvm .

--- a/graalvm/README.md
+++ b/graalvm/README.md
@@ -1,0 +1,20 @@
+# Native Spring Boot example with GraalVM
+
+This repo is an example for how a native Java application can be profiled with Parca Agent. First deploy Parca and Parca Agent as usual, for example [on Kubernetes](https://www.parca.dev/docs/kubernetes).
+
+To run this example native Java Spring Boot app on the same Kubernetes cluster execute:
+
+```bash
+kubectl run spring-boot-native-example --image=ghcr.io/parca-dev/spring-boot-native-example:v0.0.1 --port=8080
+```
+
+The important parts to make this work is to instruct `native-image` to:
+
+* Not remove all local symbols with `-H:-DeleteLocalSymbols` (see [this line in build.gradle](./build.gradle#L30))
+* Preserve the frame pointer with `-H:+PreserveFramePointer` (see [this line in build.gradle](./build.gradle#L31))
+
+## Screenshot
+
+An example screenshot of parts of an iciclegraph/flamegraph of data produced with this example:
+
+![iciclegraph](TODO)

--- a/graalvm/build.gradle
+++ b/graalvm/build.gradle
@@ -1,13 +1,13 @@
 plugins {
-	id 'org.springframework.boot' version '2.7.1'
+	id 'org.springframework.boot' version '3.0.0'
 	id 'io.spring.dependency-management' version '1.1.0'
 	id 'java'
-	id 'org.springframework.experimental.aot' version '0.12.1'
+	id 'org.graalvm.buildtools.native' version '0.9.18'
 }
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'
-sourceCompatibility = '11'
+sourceCompatibility = '17'
 
 repositories {
 	mavenCentral()
@@ -29,6 +29,10 @@ graalvmNative {
       buildArgs.addAll([
         '-H:-DeleteLocalSymbols',   // Do not use linker option to remove all local symbols from image
         '-H:+PreserveFramePointer', // Saves stack base pointer on the stack on method entry
+        //// FIXME: Try building with SourceLevelDebug (new in GraalVM 22.3)
+        //// https://github.com/oracle/graal/blob/vm-22.3.0/docs/reference-manual/native-image/DebugInfo.md
+        // '-H:+SourceLevelDebug',     // Preserve the local variable information for every Java source line
+        // '-g',                       // Generate debugging information
         '--static',                 // Build statically linked executable (optional)
       ])
     }

--- a/graalvm/build.gradle
+++ b/graalvm/build.gradle
@@ -1,0 +1,36 @@
+plugins {
+	id 'org.springframework.boot' version '2.7.1'
+	id 'io.spring.dependency-management' version '1.1.0'
+	id 'java'
+	id 'org.springframework.experimental.aot' version '0.12.1'
+}
+
+group = 'com.example'
+version = '0.0.1-SNAPSHOT'
+sourceCompatibility = '11'
+
+repositories {
+	mavenCentral()
+  maven { url 'https://repo.spring.io/release' }
+}
+
+dependencies {
+	implementation 'org.springframework.boot:spring-boot-starter-web'
+	testImplementation('org.springframework.boot:spring-boot-starter-test')
+}
+
+test {
+	useJUnitPlatform()
+}
+
+graalvmNative {
+  binaries{
+    main {
+      buildArgs.addAll([
+        '-H:-DeleteLocalSymbols',   // Do not use linker option to remove all local symbols from image
+        '-H:+PreserveFramePointer', // Saves stack base pointer on the stack on method entry
+        '--static',                 // Build statically linked executable (optional)
+      ])
+    }
+  }
+}

--- a/graalvm/deployment.yaml
+++ b/graalvm/deployment.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: demo-graalvm
+  name: graalvm
+  namespace: parca
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: demo-graalvm
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: demo-graalvm
+    spec:
+      containers:
+      - image: parca-demo:graalvm
+        name: graalvm
+        resources:
+          limits:
+            cpu: '100m'
+            memory: '256Mi'

--- a/graalvm/settings.gradle
+++ b/graalvm/settings.gradle
@@ -1,0 +1,8 @@
+pluginManagement {
+    repositories {
+        mavenCentral()
+        maven { url 'https://repo.spring.io/release' }
+    }
+}
+
+rootProject.name = 'demo'

--- a/graalvm/src/main/java/com/example/demo/Application.java
+++ b/graalvm/src/main/java/com/example/demo/Application.java
@@ -1,0 +1,33 @@
+package com.example.demo;
+
+import java.util.Arrays;
+
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+
+@SpringBootApplication
+public class Application {
+
+	public static void main(String[] args) {
+		SpringApplication.run(Application.class, args);
+	}
+
+	@Bean
+	public CommandLineRunner commandLineRunner(ApplicationContext ctx) {
+		return args -> {
+
+			System.out.println("Let's inspect the beans provided by Spring Boot:");
+
+			String[] beanNames = ctx.getBeanDefinitionNames();
+			Arrays.sort(beanNames);
+			for (String beanName : beanNames) {
+				System.out.println(beanName);
+			}
+
+		};
+	}
+
+}

--- a/graalvm/src/main/java/com/example/demo/HelloController.java
+++ b/graalvm/src/main/java/com/example/demo/HelloController.java
@@ -1,0 +1,14 @@
+package com.example.demo;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HelloController {
+
+	@GetMapping("/")
+	public String index() {
+		return "Greetings from native Spring Boot Parca Example!";
+	}
+
+}

--- a/graalvm/src/test/java/com/example/demo/DemoApplicationTests.java
+++ b/graalvm/src/test/java/com/example/demo/DemoApplicationTests.java
@@ -1,0 +1,13 @@
+package com.example.demo;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class DemoApplicationTests {
+
+	@Test
+	void contextLoads() {
+	}
+
+}


### PR DESCRIPTION
## Motivation

[GraalVM](https://graalvm.org) is an alternative runtime to JVM (and [other languages](https://www.graalvm.org/22.0/reference-manual/languages/) like JS, Python...):

> Compile Java applications ahead-of-time to native binaries that start up instantly and deliver peak performance with no warmup time

Running a JVM inside a container can feel redundant, and the resource overhead needed for the JVM is especially obvious when it comes to micro-services. For anyone looking to reduce cost and improve performance (like Parca users), replacing JVM by GraalVM can have huge benefits:

![quarkus_metrics_graphic_bootmem](https://quarkus.io/assets/images/quarkus_metrics_graphic_bootmem_wide.png)

(Image source: [quarkus.io/#container-first](https://quarkus.io/#container-first))

## Changes

This is the same Spring Boot app as the Java example, but compiled into a static native binary with GraalVM


With JVM:

```
Started Application in 1.224 seconds (JVM running for 1.463)
```

With GraalVM :racing_car::

```
Started Application in 0.026 seconds (JVM running for 0.027)
```

## How to test

```shell
# Build
cd graalvm/
make build

# Run
docker run --rm --name parca-demo-graalvm -p 8080:8080 parca-demo:graalvm

# Generate HTTP traffic
while :; do curl -sSf http://127.0.0.1:8080/ >/dev/null; done

# Run parca and parca-agent
# https://www.parca.dev/docs/binary
# https://www.parca.dev/docs/agent-binary
```

The binary being compiled statically, you can also extract it and run it locally on Linux:

```shell
# Copy binary from container
docker cp parca-demo-graalvm:/bin/demo .

# Run
./demo
```
 

## Resources

* https://www.graalvm.org/native-image/
* https://docs.spring.io/spring-native/docs/current/reference/htmlsingle/
* https://quarkus.io/guides/native-reference#generating-flame-graphs-is-slow-or-produces-errors-what-can-i-do