### PR TITLE
feat: add Java example with libperf-jvmti.so agent

### DIFF
--- a/java/Dockerfile.libperf
+++ b/java/Dockerfile.libperf
@@ -1,0 +1,32 @@
+# vim: ft=dockerfile
+FROM docker.io/fedora:37 as base
+
+# hadolint ignore=DL3041
+RUN dnf -y install --repo=fedora \
+      java \
+    && dnf -y clean all
+
+FROM docker.io/fedora:37 as build
+
+WORKDIR /src
+
+# hadolint ignore=DL3041
+RUN dnf -y install --repo=fedora \
+      java-devel \
+      perf \
+    && dnf -y clean all
+
+COPY . /src
+
+RUN ./gradlew build --no-daemon
+
+FROM base
+
+WORKDIR /app
+
+COPY --from=build /usr/lib64/libperf-jvmti.so /app
+COPY --from=build /src/build/libs/demo-0.0.1-SNAPSHOT.jar /app/demo.jar
+
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseContainerSupport", "-XX:+PreserveFramePointer", "-agentpath:/app/libperf-jvmti.so", "-Djava.security.egd=file:/dev/./urandom", "-jar", "/app/demo.jar"]

--- a/java/Makefile
+++ b/java/Makefile
@@ -1,3 +1,7 @@
 .PHONY: build
 build:
 	docker build -t parca-demo:java .
+
+.PHONY: build-libperf
+build-libperf:
+	docker build -f Dockerfile.libperf -t parca-demo:java-libperf .


### PR DESCRIPTION
This uses Perf JVMI agent to create a jitdump file: https://github.com/torvalds/linux/tree/master/tools/perf/jvmti

The example uses Fedora which is the only distribution packaging the agent, this has the disadvantage of requiring to use the Java version provided by the `java` meta package. Otherwise, the user must compile the agent themselves for their JDK version. 

Blockers:

* parca-dev/parca-agent#1051
* ~~Even with the above PR merged, the agent would be unable to find the dump which goes into a temporary directory following the pattern `${JITDUMPDIR:-${HOME:-.}}/.debug/jit/java-jit-YYYYMMDD.XXXXXXXX/jit-${PID}.dump`~~