### PR TITLE
feat: add PHP example

### DIFF
--- a/deploy-apps.sh
+++ b/deploy-apps.sh
@@ -32,6 +32,11 @@ echo "Building the Python demo"
 make -C python build
 kubectl apply -f ./python/deployment.yaml
 
+echo "Building the PHP demo"
+
+make -C php build
+kubectl apply -f ./php/deployment.yaml
+
 echo "Building the NodeJS demo"
 
 make -C nodejs build

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -1,0 +1,7 @@
+FROM docker.io/php:8.1-alpine
+
+WORKDIR /app
+
+COPY demo.php .
+
+CMD ["php", "-d", "zend_extension=opcache.so", "-d", "opcache.enable_cli=1", "-d", "opcache.jit=function", "-d", "opcache.jit_buffer_size=64M", "-d", "opcache.jit_debug=0x10", "demo.php"]

--- a/php/Makefile
+++ b/php/Makefile
@@ -1,0 +1,3 @@
+.PHONY: build
+build:
+	docker build -t parca-demo:php .

--- a/php/README.md
+++ b/php/README.md
@@ -1,0 +1,11 @@
+# PHP
+
+Requires PHP 8 or above with JIT compiler enabled.
+
+See:
+
+* https://wiki.php.net/rfc/jit#phpini_defaults
+* https://www.php.net/manual/en/opcache.configuration.php
+* https://github.com/php/php-src/blob/master/ext/opcache/jit/zend_jit.h
+
+`opcache.jit_debug=0x10` enables Perf map, `opcache.jit_debug=0x20` enables JITDUMP, `opcache.jit_debug=0x30` enables both.

--- a/php/demo.php
+++ b/php/demo.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+function Fibonacci(int $n): int {
+    $a = 0;
+    $b = 1;
+    $tmp = 0;
+
+    for ($i = 0; $i < $n; $i++) {
+        $tmp = $a;
+        $a = $b;
+        $b += $tmp;
+    }
+
+    return $a;
+}
+
+while (1) {
+  echo Fibonacci(42) . PHP_EOL;
+}
+
+?>

--- a/php/deployment.yaml
+++ b/php/deployment.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: demo-php
+  name: php
+  namespace: parca
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: demo-php
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: demo-php
+    spec:
+      containers:
+      - image: parca-demo:php
+        name: php
+        resources:
+          limits:
+            cpu: '100m'
+            memory: '256Mi'


### PR DESCRIPTION
Requires PHP 8 or above with JIT compiler enabled.

Supports Perf map and jitdump.

![image](https://user-images.githubusercontent.com/32458727/203182772-eba281f5-8ccd-414a-a419-f5a0f3a40eb6.png)