### PR TITLE
feat(python): enable Perf map support

### DIFF
--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,7 +1,9 @@
-FROM python:3.10-alpine
+FROM python:3.12-rc-bullseye
 
-WORKDIR /usr/src/app
+ENV PYTHONPERFSUPPORT=1
 
-COPY . .
+WORKDIR /app
 
-CMD [ "python", "./main.py" ]
+COPY main.py .
+
+CMD [ "python", "main.py" ]

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,3 @@
+# Python
+
+See https://docs.python.org/3.12/howto/perf_profiling.html#perf-profiling

--- a/python/main.py
+++ b/python/main.py
@@ -1,10 +1,12 @@
-import time 
+import time
+
 
 def fibonacci(n):
     if n == 1 or n == 2:
         return 1
     else:
         return fibonacci(n - 1) + fibonacci(n - 2)
+
 
 while True:
     print(fibonacci(42))


### PR DESCRIPTION
Requires Python 3.12. Alpine cannot be used as it is not built with Perf support.

![image](https://user-images.githubusercontent.com/32458727/203186209-f9a6b18c-a7d0-4479-bf48-542bf644f180.png)

![image](https://user-images.githubusercontent.com/32458727/203186271-39dabe8b-656e-4c83-b4df-7f8f04ca7870.png)