### PR TITLE
Updating the deploy-apps script

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,22 +31,60 @@ Check out the `start.sh` and see if there is any parameter like CPUs and memory 
 
 If you're happy with the parameters, start the VM by running:
 ```
-./start.sh
+$ ./start.sh
 ```
 
 Once minikube is up and running you can deploy Parca and monitoring stack:
 ```
-./deploy-infra.sh
+$ ./deploy-infra.sh
 ```
 
 After that you can deploy the demo applications by running:
 ```
-./deploy-apps.sh
+$ ./deploy-apps.sh
+
+Available deployments:
+  1 [ ] c
+  2 [ ] cpp
+  3 [ ] dotnet
+  4 [ ] go-cgo
+  5 [ ] go
+  6 [ ] java
+  7 [ ] julia
+  8 [ ] nextjs
+  9 [ ] nodejs
+ 10 [ ] php
+ 11 [ ] python
+ 12 [ ] rust
+Type to check deployments (again to uncheck, ENTER when done): 
+```
+
+Type in the number/name of the demos you want to deploy:
+```
+Type to check deployments (again to uncheck, ENTER when done): cpp 6 rust
+```
+```
+Available deployments:
+  1 [ ] c
+  2 [X] cpp
+  3 [ ] dotnet
+  4 [ ] go-cgo
+  5 [ ] go
+  6 [X] java
+  7 [ ] julia
+  8 [ ] nextjs
+  9 [ ] nodejs
+ 10 [ ] php
+ 11 [ ] python
+ 12 [X] rust
+Type to check deployments (again to uncheck, ENTER when done): 
 ```
 
 Note: This will take some time to pull down base images and build each language's demo.
 
 At the end you should have a demo for each language in the cluster.
+
+Tip: You can also deploy the demos in one line: ```./deploy-apps.sh cpp java rust```
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Available deployments:
  10 [ ] php
  11 [ ] python
  12 [ ] rust
-Type to check deployments (again to uncheck, ENTER when done): 
+Type to check deployments (again to uncheck, ENTER when done):
 ```
 
 Type in the number/name of the demos you want to deploy:
@@ -77,7 +77,7 @@ Available deployments:
  10 [ ] php
  11 [ ] python
  12 [X] rust
-Type to check deployments (again to uncheck, ENTER when done): 
+Type to check deployments (again to uncheck, ENTER when done):
 ```
 
 Note: This will take some time to pull down base images and build each language's demo.

--- a/deploy-apps.sh
+++ b/deploy-apps.sh
@@ -1,82 +1,79 @@
 #!/user/bin/env bash
 set -euo pipefail
 
-
 DEPLOYMENT_FILE="deployment.yaml"
-DEPLOYMENTS_GLOB=( ./*/"$DEPLOYMENT_FILE" )
+DEPLOYMENTS_GLOB=(./*/"$DEPLOYMENT_FILE")
 STARTING_PROMPT="Available deployments:"
 SELECTION_PROMPT="Type to check deployments (again to uncheck, ENTER when done): "
 NOT_FOUND_ERROR="Error! Not found: "
 SELECTION_CHAR="X"
 
-
-g_selections=() # Used to track what deployments the user has already selected
+g_selections=()        # Used to track what deployments the user has already selected
 g_invalidSelections=() # Used to track what response tokens did not match to a deployment
-g_deploymentFiles=() # Used to track the pathname of deployment.yaml files
-g_deploymentDirs=() # Used to track the dirs which contain a deployment.yaml file
-
+g_deploymentFiles=()   # Used to track the pathname of deployment.yaml files
+g_deploymentDirs=()    # Used to track the dirs which contain a deployment.yaml file
 
 # This function gets called once before building any of the deployments are built
-function preBuildSteps () {
-  eval "$(minikube -p parca-demo docker-env)"
+function preBuildSteps() {
+    eval "$(minikube -p parca-demo docker-env)"
 }
 
 # This function gets called once for each deployment the user selected to build
 #
 # arg 1: the directory the deployment is found
 # arg 2: the path to the deployment file
-function buildSteps () {
-  printf 'Building the "%s" demo\n' "${1}"
-  make -C "$1" build
-  kubectl apply -f "$2"
+function buildSteps() {
+    printf 'Building the "%s" demo\n' "${1}"
+    make -C "$1" build
+    kubectl apply -f "$2"
 }
 
 # This function collects the names and the deployment.yaml files for each deployment
-function findDeployments () {
-  local file
+function findDeployments() {
+    local file
 
-  for file in "${DEPLOYMENTS_GLOB[@]}" ;  do
-    if [ -e "$file" ] ; then  # Make sure it isn't an empty match
-      g_deploymentFiles+=("$file")
-      g_deploymentDirs+=( "$(basename "$(dirname "$file")")" )
-      g_selections+=( "" ) # mark as not selected
-    fi
-  done
+    for file in "${DEPLOYMENTS_GLOB[@]}"; do
+        if [ -e "$file" ]; then # Make sure it isn't an empty match
+            g_deploymentFiles+=("$file")
+            g_deploymentDirs+=("$(basename "$(dirname "$file")")")
+            g_selections+=("") # mark as not selected
+        fi
+    done
 }
 
 # This function checks if a deployment is already selected or not then toggles it
 #
 # arg 1: the 0-based deployment index to toggle
-function toggleSelection () {
-  if [ "${g_selections[$1]}" == "" ] ; then
-    g_selections[$1]="$SELECTION_CHAR"
-  elif [ "${g_selections[$1]}" == "$SELECTION_CHAR" ] ; then
-    g_selections[$1]=""
-  fi
+function toggleSelection() {
+    if [ "${g_selections[$1]}" == "" ]; then
+        g_selections[$1]="$SELECTION_CHAR"
+    elif [ "${g_selections[$1]}" == "$SELECTION_CHAR" ]; then
+        g_selections[$1]=""
+    fi
 }
 
 # This function parses a user's string response token by checking if there are any
 # deployments with the same name and returns its 0-based index
 #
 # arg 1: user's response token
-function findDeploymentIndexFromString () {
-  local i
+function findDeploymentIndexFromString() {
+    local i
 
-  for i in "${!g_deploymentDirs[@]}" ; do
-    if [ "${g_deploymentDirs[$i]}" == "$1" ] ; then
-      echo "$i"
-    fi
-  done
+    for i in "${!g_deploymentDirs[@]}"; do
+        if [ "${g_deploymentDirs[$i]}" == "$1" ]; then
+            echo "$i"
+        fi
+    done
 }
 
 # This function parses a user's valid integer response token by changing their
 # 1-based index to a 0-based index
 #
 # arg 1: user's response token
-function findDeploymentIndexFromInteger () {
-  if [ 1 -le "$1" ] && [ "$1" -le "${#g_selections[@]}" ] ; then
-    echo "$(($1 - 1))"
-  fi
+function findDeploymentIndexFromInteger() {
+    if [ 1 -le "$1" ] && [ "$1" -le "${#g_selections[@]}" ]; then
+        echo "$(($1 - 1))"
+    fi
 }
 
 # This function attempts to match the user's response token to a valid deployment
@@ -84,125 +81,123 @@ function findDeploymentIndexFromInteger () {
 # an integer or a string
 #
 # arg 1: user's response token
-function findDeploymentIndex () {
-  local deploymentIndex
+function findDeploymentIndex() {
+    local deploymentIndex
 
-  deploymentIndex=$(findDeploymentIndexFromInteger "$1")
-  if [ "$deploymentIndex" ] ; then
-    echo "$deploymentIndex"
-    return
-  fi
+    deploymentIndex=$(findDeploymentIndexFromInteger "$1")
+    if [ "$deploymentIndex" ]; then
+        echo "$deploymentIndex"
+        return
+    fi
 
-  deploymentIndex=$(findDeploymentIndexFromString "$1")
-  if [ "$deploymentIndex" ] ; then
-    echo "$deploymentIndex"
-    return
-  fi
+    deploymentIndex=$(findDeploymentIndexFromString "$1")
+    if [ "$deploymentIndex" ]; then
+        echo "$deploymentIndex"
+        return
+    fi
 }
 
 # This function parses the user's whitespace-delimited response. It identifies which
 # tokens are valid and keeps track of which ones aren't
 #
 # vargs: array of user's response tokens
-function parseResponse () {
-  local item
+function parseResponse() {
+    local item
 
-  g_invalidSelections=()
+    g_invalidSelections=()
 
-  for item in "$@" ; do
-    local deploymentIndex
+    for item in "$@"; do
+        local deploymentIndex
 
-    deploymentIndex=$(findDeploymentIndex "$item")
-    if [ "$deploymentIndex" ] ; then
-      toggleSelection "$deploymentIndex"
-    else
-      g_invalidSelections+=( "$item" )
-    fi
-  done
+        deploymentIndex=$(findDeploymentIndex "$item")
+        if [ "$deploymentIndex" ]; then
+            toggleSelection "$deploymentIndex"
+        else
+            g_invalidSelections+=("$item")
+        fi
+    done
 }
 
 # This function parses the arguments that were provided to this script in the terminal.
 # It identifies which tokens are valid and keeps track of which ones aren't.
 #
 # vargs: array of script's arguments
-function parseArguments () {
-  local item
+function parseArguments() {
+    local item
 
-  for item in "$@" ; do
-    local deploymentIndex
+    for item in "$@"; do
+        local deploymentIndex
 
-    deploymentIndex=$(findDeploymentIndexFromString "$item")
-    if [ "$deploymentIndex" ] ; then
-      toggleSelection "$deploymentIndex"
-    else
-      g_invalidSelections+=( "$item" )
-    fi
-  done
+        deploymentIndex=$(findDeploymentIndexFromString "$item")
+        if [ "$deploymentIndex" ]; then
+            toggleSelection "$deploymentIndex"
+        else
+            g_invalidSelections+=("$item")
+        fi
+    done
 }
 
 # This function prints the list of deployments a user can select alongside an index
 # and a text-based checkbox to indicate if it selected already
-function printDeploymentOptions () {
-  local i
+function printDeploymentOptions() {
+    local i
 
-  echo # blank line
-  echo "$STARTING_PROMPT"
-  for i in "${!g_deploymentDirs[@]}" ; do
-    printf "%3s [%1s] %s\n" "$((i+1))" "${g_selections[$i]}" "${g_deploymentDirs[$i]}"
-  done
+    echo # blank line
+    echo "$STARTING_PROMPT"
+    for i in "${!g_deploymentDirs[@]}"; do
+        printf "%3s [%1s] %s\n" "$((i + 1))" "${g_selections[$i]}" "${g_deploymentDirs[$i]}"
+    done
 }
 
 # This function prints the list of invalid selections the user made
-function printInvalidSelections () {
-  if [ "${#g_invalidSelections[@]}" -ne 0 ] ; then
-    echo "$NOT_FOUND_ERROR ${g_invalidSelections[*]}"
-    return 1
-  fi
+function printInvalidSelections() {
+    if [ "${#g_invalidSelections[@]}" -ne 0 ]; then
+        echo "$NOT_FOUND_ERROR ${g_invalidSelections[*]}"
+        return 1
+    fi
 }
 
 # This function displays the list of deployments to the users and records their
 # input in a loop until they pass an empty line
 function promptForDeploymentSelection() {
-  local response
+    local response
 
-  while true ; do
-    printDeploymentOptions
-    printInvalidSelections && true # Don't exit if there were invalid selections
+    while true; do
+        printDeploymentOptions
+        printInvalidSelections && true # Don't exit if there were invalid selections
 
-    read -p "$SELECTION_PROMPT" -ra response
-    if [ "${#response[@]}" -eq 0 ] ; then
-      break # no response received
-    fi
+        read -p "$SELECTION_PROMPT" -ra response
+        if [ "${#response[@]}" -eq 0 ]; then
+            break # no response received
+        fi
 
-    parseResponse "${response[@]}"
-  done
+        parseResponse "${response[@]}"
+    done
 }
 
 # This function loops though all selected deployments and builds them
-function buildSelectedDeployments () {
-  local i
+function buildSelectedDeployments() {
+    local i
 
-  for i in "${!g_selections[@]}" ; do
-    if [ "${g_selections[i]}" == "$SELECTION_CHAR" ] ; then
-      buildSteps "${g_deploymentDirs[$i]}" "${g_deploymentFiles[$i]}"
-    fi
-  done
+    for i in "${!g_selections[@]}"; do
+        if [ "${g_selections[i]}" == "$SELECTION_CHAR" ]; then
+            buildSteps "${g_deploymentDirs[$i]}" "${g_deploymentFiles[$i]}"
+        fi
+    done
 }
 
 # This function build the deployments specified as arguments to this script if there are
 # any available. Otherwise, it will prompt the user to select some.
 #
 # vargs: array of script's arguments
-function selectDeploymentsFromArgumentsElsePrompt () {
-  if [ "$#" -ne 0 ] ; then
-    parseArguments "$@"
-    printInvalidSelections
-  else
-    promptForDeploymentSelection
-  fi
+function selectDeploymentsFromArgumentsElsePrompt() {
+    if [ "$#" -ne 0 ]; then
+        parseArguments "$@"
+        printInvalidSelections
+    else
+        promptForDeploymentSelection
+    fi
 }
-
-
 
 findDeployments
 selectDeploymentsFromArgumentsElsePrompt "$@"

--- a/deploy-apps.sh
+++ b/deploy-apps.sh
@@ -1,63 +1,158 @@
 #!/bin/bash
 
-eval "$(minikube -p parca-demo docker-env)"
 
-echo "Building the Go demo"
+DEPLOYMENTS_GLOB=( ./*/deployment.yaml )
+STARTING_PROMPT="Available deployments:"
+SELECTION_PROMPT="Type to check deployments (again to uncheck, ENTER when done): "
+NOT_FOUND_ERROR="Error! Not found: "
+SELECTION_CHAR="X"
 
-make -C go build
-kubectl apply -f ./go/deployment.yaml
 
-echo "Building the CGo demo"
+g_selections=() # Used to track what deployments the user has already selected
+g_invalidSelections=() # Used to track what response tokens did not match to a deployment
+g_deploymentFiles=() # Used to track the pathname of deployment.yaml files
+g_deploymentDirs=() # Used to track the dirs which contain a deployment.yaml file
 
-make -C go-cgo build
-kubectl apply -f ./go-cgo/deployment.yaml
 
-echo "Building the C demo"
+# This function collects the names and the deployment.yaml files for each deployment
+function findDeployments () {
+  for file in "${DEPLOYMENTS_GLOB[@]}" ;  do
+    if [ -e "$file" ] ; then  # Make sure it isn't an empty match
+      g_deploymentFiles+=("$file")
+      g_deploymentDirs+=( "$(basename "$(dirname "$file")")" )
+      g_selections+=( "" ) # mark as not selected
+    fi
+  done
+}
 
-make -C c build
-kubectl apply -f ./c/deployment.yaml
+# This function checks if a deployment is already selected or not then toggles it
+#
+# arg 1: the 0-based deployment index to toggle
+function toggleSelection () {
+  if [ "${g_selections[$1]}" == "" ] ; then
+    g_selections[$1]="$SELECTION_CHAR"
+  elif [ "${g_selections[$1]}" == "$SELECTION_CHAR" ] ; then
+    g_selections[$1]=""
+  fi
+}
 
-echo "Building the C++ demo"
+# This function parses a user's string response token by checking if there are any
+# deployments with the same name and returns its 0-based index
+#
+# arg 1: user's response token
+function parseStringResponse () {
+  for i in "${!g_deploymentDirs[@]}" ; do
+    if [ "${g_deploymentDirs[$i]}" == "$1" ] ; then
+      echo "$i"
+    fi
+  done
+}
 
-make -C cpp build
-kubectl apply -f ./cpp/deployment.yaml
+# This function parses a user's valid integer response token by changing their
+# 1-based index to a 0-based index
+#
+# arg 1: user's response token
+function parseIntegerResponse () {
+  if (( 1 <= $1 && $1 <= ${#g_selections[@]} )) ; then
+    echo "$(($1 - 1))"
+  fi
+}
 
-echo "Building the Rust demo"
+# This function attempts to match the user's response token to a valid deployment
+# configuration. It calls the appropriate function depending on if the token is
+# an integer or a string
+#
+# arg 1: user's response token
+function findDeploymentIndex () {
+  deploymentIndex=$(parseIntegerResponse "$1")
+  if [ "$deploymentIndex" ] ; then
+    echo "$deploymentIndex"
+    return
+  fi
 
-make -C rust build
-kubectl apply -f ./rust/deployment.yaml
+  deploymentIndex=$(parseStringResponse "$1")
+  if [ "$deploymentIndex" ] ; then
+    echo "$deploymentIndex"
+    return
+  fi
+}
 
-echo "Building the .NET demo"
+# This function parses the user's whitespace-delimited response. It identifies which
+# tokens are valid and keeps track of which ones weren't
+#
+# vargs: array of user's response tokens
+function parseResponse () {
+  g_invalidSelections=()
 
-make -C dotnet build
-kubectl apply -f ./dotnet/deployment.yaml
+  for item in "$@" ; do
+    deploymentIndex=$(findDeploymentIndex "$item")
+    if [ "$deploymentIndex" ] ; then
+      toggleSelection "$deploymentIndex"
+    else
+      g_invalidSelections+=( "$item" )
+    fi
+  done
+}
 
-echo "Building the Python demo"
+# This function prints the list of deployments a user can select alongside an index
+# and a text-based checkbox to indicate if it selected already
+function printDeploymentOptions () {
+  echo # blank line
+  echo "$STARTING_PROMPT"
+  for i in "${!g_deploymentDirs[@]}" ; do
+    printf "%3s [%1s] %s\n" "$((i+1))" "${g_selections[$i]}" "${g_deploymentDirs[$i]}"
+  done
+}
 
-make -C python build
-kubectl apply -f ./python/deployment.yaml
+# This function prints the list of invalid selections the user made
+function printInvalidSelections () {
+  if [ "${#g_invalidSelections[@]}" -ne 0 ] ; then
+    echo "$NOT_FOUND_ERROR ${g_invalidSelections[*]}"
+  fi
+}
 
-echo "Building the Julia demo"
+# This function displays the list of deployments to the users and records their
+# input in a loop until they pass an empty line
+function promptForDeploymentSelection() {
+  while true ; do
+    printDeploymentOptions
+    printInvalidSelections
 
-make -C julia build
-kubectl apply -f ./julia/deployment.yaml
+    read -p "$SELECTION_PROMPT" -ra response
+    if [ "${#response[@]}" -eq 0 ] ; then
+      break # no response received
+    fi
 
-echo "Building the PHP demo"
+    parseResponse "${response[@]}"
+  done
+}
 
-make -C php build
-kubectl apply -f ./php/deployment.yaml
+# This function gets called once before building any of the deployments are built
+function preBuildSteps () {
+  eval "$(minikube -p parca-demo docker-env)"
+}
 
-echo "Building the NodeJS demo"
+# This function gets called once for each deployment the user selected to build
+#
+# arg 1: the directory the deployment is found
+# arg 2: the path to the deployment file
+function buildSteps () {
+  echo "Building the '$1' demo"
+  make -C "$1" build
+  kubectl apply -f "$2"
+}
 
-make -C nodejs build
-kubectl apply -f ./nodejs/deployment.yaml
+function entrypoint () {
+  findDeployments
+  promptForDeploymentSelection
 
-echo "Building the NextJS demo"
+  preBuildSteps
 
-make -C nextjs build
-kubectl apply -f ./nextjs/deployment.yaml
+  for i in "${!g_selections[@]}" ; do
+    if [ "${g_selections[i]}" == "$SELECTION_CHAR" ] ; then
+      buildSteps "${g_deploymentDirs[$i]}" "${g_deploymentFiles[$i]}"
+    fi
+  done
+}
 
-echo "Building the Java demo"
-
-make -C java build
-kubectl apply -f ./java/deployment.yaml
+entrypoint


### PR DESCRIPTION
# Problem
- Currently, the deploy-apps.sh script has no way of selectively choosing which apps to deploy. This means that users will have to wait a while for all the apps to build. Further, running all of these apps is resource-intensive. 

# Changes
- Edited the deploy-apps.sh script to allow the user to choose which apps to deploy
- updated the readme to include an example of how to use the script

# Issues
- Fixes #26