### PR TITLE
fix(julia): custom build without Frame Pointer Omission

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,7 @@ repos:
     rev: v4.4.0
     hooks:
       - id: end-of-file-fixer
+        exclude: \.patch$
       - id: trailing-whitespace
   - repo: https://github.com/hadolint/hadolint
     rev: v2.12.0

--- a/julia/Makefile
+++ b/julia/Makefile
@@ -1,3 +1,7 @@
 .PHONY: build
 build:
 	docker build -t parca-demo:julia .
+
+build-patched:
+	docker run --interactive --rm --volume="${PWD}:/build" --workdir=/build \
+		docker.io/nixos/nix:2.11.1 sh -c '$$(nix-build --no-out-link)' | docker load

--- a/julia/default.nix
+++ b/julia/default.nix
@@ -1,0 +1,25 @@
+{ pkgs ? import
+    (builtins.fetchTarball
+      "https://github.com/NixOS/nixpkgs/archive/nixos-22.11.tar.gz"
+    )
+    { }
+}:
+
+pkgs.dockerTools.streamLayeredImage {
+  name = "parca-demo";
+  tag = "julia";
+  contents = [
+    (pkgs.julia.overrideAttrs (current: {
+      patches = current.patches ++ [
+        ./patches/0001-disable-frame-pointer-omission.patch
+      ];
+      doInstallCheck = false;
+    }))
+    (pkgs.writeTextDir "app/main.jl" (builtins.readFile ./main.jl))
+  ];
+  config = {
+    Cmd = [ "julia" "main.jl" ];
+    Env = [ "ENABLE_JITPROFILING=1" ];
+    WorkingDir = "/app";
+  };
+}

--- a/julia/patches/0001-disable-frame-pointer-omission.patch
+++ b/julia/patches/0001-disable-frame-pointer-omission.patch
@@ -1,0 +1,20 @@
+commit 1d5a4168933d19df4784aa6c73a5a7653610cf04
+Author: Maxime Brunet <max@brnt.mx>
+Date:   Sat Feb 11 11:37:06 2023 -0800
+
+    Disable Frame Pointer Omission on Linux
+
+diff --git a/src/codegen.cpp b/src/codegen.cpp
+index 104f77f8d6..5a1284be6d 100644
+--- a/src/codegen.cpp
++++ b/src/codegen.cpp
+@@ -10,7 +10,7 @@
+ #if defined(_CPU_X86_)
+ #define JL_NEED_FLOATTEMP_VAR 1
+ #endif
+-#if defined(_OS_WINDOWS_) || defined(_OS_FREEBSD_)
++#if defined(_OS_WINDOWS_) || defined(_OS_LINUX_) || defined(_OS_FREEBSD_)
+ #define JL_DISABLE_FPO
+ #endif
+
+


### PR DESCRIPTION
Frame Point Omission is enabled by default on Linux and not configurable: JuliaLang/julia#40655

This re-uses the Nix package by applying a patch to it, and avoids messing with the Julia's many build dependencies directly. 

Opened for the record, hardly supportable by us, build is long (~1h on my machine), we would probably need to publish the built image, better wait for an improvement from the Julia project.

![image](https://user-images.githubusercontent.com/32458727/218359178-287e2a79-7f88-4310-b054-4e61d857c78a.png)


ref: https://github.com/parca-dev/parca-demo/issues/8