### PR TITLE
fix(dotnet): cover dotnet container requirements

### DIFF
--- a/dotnet/Dockerfile
+++ b/dotnet/Dockerfile
@@ -18,7 +18,9 @@ FROM build AS publish
 RUN dotnet publish "demo.csproj" -c Release -o /app/publish
 
 FROM base AS final
+ENV DOTNET_EnableWriteXorExecute=0
 ENV DOTNET_PerfMapEnabled=1
+ENV DOTNET_EnableEventLog=1
 WORKDIR /app
 COPY --from=publish /app/publish .
 ENTRYPOINT ["dotnet", "demo.dll"]

--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -1,3 +1,3 @@
 # .NET
 
-See https://learn.microsoft.com/en-us/dotnet/core/runtime-config/debugging-profiling#export-perf-maps
+See https://learn.microsoft.com/en-us/dotnet/core/diagnostics/diagnostics-in-containers#using-perfcollect-in-a-container

--- a/dotnet/deployment.yaml
+++ b/dotnet/deployment.yaml
@@ -22,3 +22,6 @@ spec:
           limits:
             cpu: '100m'
             memory: '256Mi'
+        securityContext:
+          capabilities:
+            - SYS_ADMIN


### PR DESCRIPTION
### Problem
Agent can't read dotnet application's data and log:
`level=debug name=parca-agent ts=2023-07-27T16:23:24.738406352Z caller=cpu.go:316 component=cpu_profiler msg="failed to prefetch process info" pid=605299 err="failed to open proc 605299: stat /proc/605299: no such file or directory"`

### Changes
According to [this documentation](https://learn.microsoft.com/en-us/dotnet/core/diagnostics/diagnostics-in-containers#using-perfcollect-in-a-container) the changes are:
- Add two required variables
- Add SYS_ADMIN capability