### PR TITLE
fix: minikube start.sh

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 minikube start -p parca-demo \
     --driver=virtualbox \
-    --runtime=docker \
+    --container-runtime=docker \
     --kubernetes-version=stable \
     --cpus=4 \
     --memory=16gb \


### PR DESCRIPTION
These days I am playing around with Parca with Python and I find that the parca-demo's start.sh is outdated with the recent version of minikube.